### PR TITLE
Manual Clearing and Defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dirty"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Tom Burdick <thomas.burdick@gmail.com>"]
-description = "Holds a value with a dirty flag which is set on writes and cleared on reads"
+description = "Holds a value with a dirty flag which is set on writes and cleared on clear()"
 documentation = "https://bfrog.github.io/dirty"
 homepage = "https://github.com/bfrog/dirty"
 repository = "https://github.com/bfrog/dirty"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,16 @@ impl<T> Dirty<T> {
     }
 }
 
-impl<T> Deref for Dirty<T>{
+impl<T> Deref for Dirty<T> {
     type Target = T;
     fn deref(&self) -> &T {
         &self.value
+    }
+}
+
+impl<T> Default for Dirty<T> where T: Default {
+    fn default() -> Self {
+        Dirty::new(T::default())
     }
 }
 
@@ -105,6 +111,12 @@ mod tests {
     #[test]
     fn access_inner_deref() {
         let dirty = Dirty::new(0);
+        assert!(*dirty == 0);
+    }
+    
+    #[test]
+    fn default_value() {
+        let dirty = Dirty::<i32>::default();
         assert!(*dirty == 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ impl<T> Dirty<T> {
     }
 
     /// Returns true if dirty, false otherwise.
-    #[allow(dead_code)]
     pub fn dirty(&self) -> bool {
         self.dirty
     }
@@ -40,7 +39,6 @@ impl<T> Dirty<T> {
     }
 
     /// Read the value only if modified since last read.
-    #[allow(dead_code)]
     pub fn read_dirty(&self) -> Option<&T> {
         match self.dirty {
             true => {
@@ -71,15 +69,15 @@ mod tests {
     #[test]
     fn new_dirty() {
         let dirty = Dirty::new(0);
-        assert!(dirty.dirty() == true);
+        assert!(dirty.dirty());
     }
 
     #[test]
-    fn read_doesnt_clears_flag() {
+    fn read_doesnt_clear_flag() {
         let dirty = Dirty::new(0);
-        assert!(dirty.dirty() == true);
+        assert!(dirty.dirty());
         assert!(*dirty.read() == 0);
-        assert!(dirty.dirty() == true);
+        assert!(dirty.dirty());
     }
 
     #[test]
@@ -87,9 +85,9 @@ mod tests {
         let mut dirty = Dirty::new(0);
         assert!(*dirty.read() == 0);
         dirty.clear();
-        assert!(dirty.dirty() == false);
+        assert!(!dirty.dirty());
         *dirty.write() += 1;
-        assert!(dirty.dirty() == true);
+        assert!(dirty.dirty());
     }
 
     #[test]
@@ -97,14 +95,14 @@ mod tests {
         let mut dirty = Dirty::new(0);
         assert!(dirty.read_dirty().is_some());
 		dirty.clear();
-        assert!(dirty.dirty() == false);
+        assert!(!dirty.dirty());
         assert!(dirty.read_dirty() == None);
-        assert!(dirty.dirty() == false);
+        assert!(!dirty.dirty());
         *dirty.write() += 1;
-        assert!(dirty.dirty() == true);
+        assert!(dirty.dirty());
         assert!(dirty.read_dirty().is_some());
 		dirty.clear();
-        assert!(dirty.dirty() == false);
+        assert!(!dirty.dirty());
         assert!(dirty.read_dirty() == None);
     }
     


### PR DESCRIPTION
Allows it to be use in multithread contexts.

This is a breaking change, thus the version numbering change.

Here is my use case:
-Write to the dirty.
-Read multiple times in a multiple threads.
-Clear the dirty flag at the end.

This PR also adds a Default implementation to Dirty<T> only where T: Default