### PR TITLE
`new_clean`, `unwrap` and common derivable traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirty"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Tom Burdick <thomas.burdick@gmail.com>"]
 description = "Holds a value with a dirty flag which is set on writes and cleared on clear()"
 documentation = "https://bfrog.github.io/dirty"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,14 @@ impl<T> Dirty<T> {
         }
     }
 
+    /// Create a new Dirty with a clear dirty flag.
+    pub fn new_clean(val: T) -> Dirty<T> {
+        Dirty {
+            value: val,
+            dirty: false,
+        }
+    }
+
     /// Returns true if dirty, false otherwise.
     pub fn dirty(&self) -> bool {
         self.dirty
@@ -70,6 +78,12 @@ mod tests {
     fn new_dirty() {
         let dirty = Dirty::new(0);
         assert!(dirty.dirty());
+    }
+
+    #[test]
+    fn new_dirty_clean() {
+        let dirty = Dirty::new(0);
+        assert!(!dirty.dirty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn new_dirty_clean() {
-        let dirty = Dirty::new(0);
+        let dirty = Dirty::new_clean(0);
         assert!(!dirty.dirty());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 /// Dirty wraps a value of type T with functions similiar to that of a Read/Write
 /// lock but simply sets a dirty flag on write(), reset on clear().
 /// Use read() or deref (*dirty_variable) to access the inner value.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Default, Hash)]
 pub struct Dirty<T> {
     value: T,
     dirty: bool,
@@ -61,12 +62,6 @@ impl<T> Deref for Dirty<T> {
     type Target = T;
     fn deref(&self) -> &T {
         &self.value
-    }
-}
-
-impl<T> Default for Dirty<T> where T: Default {
-    fn default() -> Self {
-        Dirty::new(T::default())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl<T> Dirty<T> {
     pub fn read(&self) -> &T {
         &self.value
     }
-    
+
     /// Clears the dirty flag.
     pub fn clear(&mut self) {
         self.dirty = false;
@@ -50,11 +50,14 @@ impl<T> Dirty<T> {
     /// Read the value only if modified since last read.
     pub fn read_dirty(&self) -> Option<&T> {
         match self.dirty {
-            true => {
-                Some(&self.value)
-            },
+            true => Some(&self.value),
             false => None,
         }
+    }
+
+    /// Consumes the wrapper and returns the enclosed value
+    pub fn unwrap(self) -> T {
+        self.value
     }
 }
 
@@ -103,27 +106,34 @@ mod tests {
     fn read_dirty() {
         let mut dirty = Dirty::new(0);
         assert!(dirty.read_dirty().is_some());
-		dirty.clear();
+        dirty.clear();
         assert!(!dirty.dirty());
         assert!(dirty.read_dirty() == None);
         assert!(!dirty.dirty());
         *dirty.write() += 1;
         assert!(dirty.dirty());
         assert!(dirty.read_dirty().is_some());
-		dirty.clear();
+        dirty.clear();
         assert!(!dirty.dirty());
         assert!(dirty.read_dirty() == None);
     }
-    
+
     #[test]
     fn access_inner_deref() {
         let dirty = Dirty::new(0);
         assert!(*dirty == 0);
     }
-    
+
     #[test]
     fn default_value() {
         let dirty = Dirty::<i32>::default();
         assert!(*dirty == 0);
+    }
+
+    #[test]
+    fn unwrap() {
+        let mut dirty = Dirty::new(100);
+        *dirty.write() = 200;
+        assert_eq!(dirty.unwrap(), 200);
     }
 }


### PR DESCRIPTION
This PR adds:

- `new_clean` to create a `Dirty<T>` without setting the flag.
- `unwrap` to consume the wrapper and return the inner value
- derive `Copy`, `Clone`, `PartialEq`, `PartialOrd`, `Eq`, `Ord`, `Debug`, `Default` and `Hash`
